### PR TITLE
Fix concurrency issues

### DIFF
--- a/DBetter.Domain/TrainRuns/Entities/TrainRunPassengerInformation.cs
+++ b/DBetter.Domain/TrainRuns/Entities/TrainRunPassengerInformation.cs
@@ -24,11 +24,12 @@ public class TrainRunPassengerInformation : Entity<TrainRunPassengerInformationI
         ToStopIndex = toStopIndex;
     }
 
-    public static TrainRunPassengerInformation Create(
+    internal static TrainRunPassengerInformation Create(
+        TrainRunPassengerInformationId id,
         PassengerInformationId informationId,
         StopIndex fromStopIndex,
         StopIndex toStopIndex)
     {
-        return new  TrainRunPassengerInformation(TrainRunPassengerInformationId.CreateNew(), informationId, fromStopIndex, toStopIndex);
+        return new  TrainRunPassengerInformation(id, informationId, fromStopIndex, toStopIndex);
     }
 }

--- a/DBetter.Domain/TrainRuns/TrainRun.cs
+++ b/DBetter.Domain/TrainRuns/TrainRun.cs
@@ -90,11 +90,17 @@ public class TrainRun : AggregateRoot<TrainRunId>
                 remainingPassengerInformation.Remove(incoming);
             }
         }
+        
+        var nextId = _passengerInformation.Any() 
+            ? (ushort) (_passengerInformation.Max(p => p.Id.Value) + 1) 
+            : (ushort) 0;
 
         foreach (var passengerInformation in remainingPassengerInformation)
         {
-            var trainRunPassengerInformation = TrainRunPassengerInformation.Create(passengerInformation.Id, passengerInformation.FromStopIndex, passengerInformation.ToStopIndex);
+            var trainRunPassengerInformation =
+                TrainRunPassengerInformation.Create(new TrainRunPassengerInformationId(nextId), passengerInformation.Id, passengerInformation.FromStopIndex, passengerInformation.ToStopIndex);
             _passengerInformation.Add(trainRunPassengerInformation);
+            nextId++;
         }
     }
 }

--- a/DBetter.Domain/TrainRuns/ValueObjects/TrainRunPassengerInformationId.cs
+++ b/DBetter.Domain/TrainRuns/ValueObjects/TrainRunPassengerInformationId.cs
@@ -3,20 +3,4 @@ using DBetter.Domain.Errors;
 
 namespace DBetter.Domain.TrainRuns.ValueObjects;
 
-public record TrainRunPassengerInformationId(Guid Value)
-{
-    public static TrainRunPassengerInformationId CreateNew()
-    {
-        return new(Guid.NewGuid());
-    }
-
-    public static CanFail<TrainRunPassengerInformationId> Create(string value)
-    {
-        if (Guid.TryParse(value, out var guid))
-        {
-            return new TrainRunPassengerInformationId(guid);
-        }
-
-        return DomainErrors.TrainRun.PassengerInformation.Id.Invalid(value);
-    }
-}
+public record TrainRunPassengerInformationId(ushort Value);

--- a/DBetter.Infrastructure/Migrations/20260404154244_TrainRunPassengerInformationKeyTest.Designer.cs
+++ b/DBetter.Infrastructure/Migrations/20260404154244_TrainRunPassengerInformationKeyTest.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DBetter.Infrastructure.Postgres;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DBetter.Infrastructure.Migrations
 {
     [DbContext(typeof(DBetterContext))]
-    partial class DBetterContextModelSnapshot : ModelSnapshot
+    [Migration("20260404154244_TrainRunPassengerInformationKeyTest")]
+    partial class TrainRunPassengerInformationKeyTest
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DBetter.Infrastructure/Migrations/20260404154244_TrainRunPassengerInformationKeyTest.cs
+++ b/DBetter.Infrastructure/Migrations/20260404154244_TrainRunPassengerInformationKeyTest.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DBetter.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class TrainRunPassengerInformationKeyTest : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_TrainRunPassengerInformation",
+                table: "TrainRunPassengerInformation");
+
+            migrationBuilder.DropIndex(
+                name: "IX_TrainRunPassengerInformation_TrainRunId",
+                table: "TrainRunPassengerInformation");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_TrainRunPassengerInformation",
+                table: "TrainRunPassengerInformation",
+                columns: new[] { "TrainRunId", "Id" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_TrainRunPassengerInformation",
+                table: "TrainRunPassengerInformation");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_TrainRunPassengerInformation",
+                table: "TrainRunPassengerInformation",
+                column: "Id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TrainRunPassengerInformation_TrainRunId",
+                table: "TrainRunPassengerInformation",
+                column: "TrainRunId");
+        }
+    }
+}

--- a/DBetter.Infrastructure/Migrations/20260405102744_RemoveTrainRunPassengerInformation.Designer.cs
+++ b/DBetter.Infrastructure/Migrations/20260405102744_RemoveTrainRunPassengerInformation.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DBetter.Infrastructure.Postgres;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DBetter.Infrastructure.Migrations
 {
     [DbContext(typeof(DBetterContext))]
-    partial class DBetterContextModelSnapshot : ModelSnapshot
+    [Migration("20260405102744_RemoveTrainRunPassengerInformation")]
+    partial class RemoveTrainRunPassengerInformation
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -1138,39 +1141,6 @@ namespace DBetter.Infrastructure.Migrations
                         });
 
                     b.Navigation("Vehicles");
-                });
-
-            modelBuilder.Entity("DBetter.Infrastructure.TrainRuns.TrainRunPersistenceDto", b =>
-                {
-                    b.OwnsMany("DBetter.Infrastructure.TrainRuns.TrainRunPassengerInformationPersistenceDto", "PassengerInformation", b1 =>
-                        {
-                            b1.Property<Guid>("TrainRunId")
-                                .HasColumnType("uuid");
-
-                            b1.Property<int>("Id")
-                                .HasColumnType("integer");
-
-                            b1.Property<int>("FromStopIndex")
-                                .HasColumnType("integer");
-
-                            b1.Property<Guid>("PassengerInformationId")
-                                .HasColumnType("uuid");
-
-                            b1.Property<int>("ToStopIndex")
-                                .HasColumnType("integer");
-
-                            b1.HasKey("TrainRunId", "Id");
-
-                            b1.HasIndex("Id", "TrainRunId")
-                                .IsUnique();
-
-                            b1.ToTable("TrainRunPassengerInformation", (string)null);
-
-                            b1.WithOwner()
-                                .HasForeignKey("TrainRunId");
-                        });
-
-                    b.Navigation("PassengerInformation");
                 });
 #pragma warning restore 612, 618
         }

--- a/DBetter.Infrastructure/Migrations/20260405102744_RemoveTrainRunPassengerInformation.cs
+++ b/DBetter.Infrastructure/Migrations/20260405102744_RemoveTrainRunPassengerInformation.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DBetter.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveTrainRunPassengerInformation : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "TrainRunPassengerInformation");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "TrainRunPassengerInformation",
+                columns: table => new
+                {
+                    TrainRunId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    FromStopIndex = table.Column<int>(type: "integer", nullable: false),
+                    PassengerInformationId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ToStopIndex = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TrainRunPassengerInformation", x => new { x.TrainRunId, x.Id });
+                    table.ForeignKey(
+                        name: "FK_TrainRunPassengerInformation_TrainRuns_TrainRunId",
+                        column: x => x.TrainRunId,
+                        principalTable: "TrainRuns",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TrainRunPassengerInformation_Id_TrainRunId",
+                table: "TrainRunPassengerInformation",
+                columns: new[] { "Id", "TrainRunId" },
+                unique: true);
+        }
+    }
+}

--- a/DBetter.Infrastructure/Migrations/20260405103025_TrainRunPassengerInformationShortId.Designer.cs
+++ b/DBetter.Infrastructure/Migrations/20260405103025_TrainRunPassengerInformationShortId.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DBetter.Infrastructure.Postgres;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DBetter.Infrastructure.Migrations
 {
     [DbContext(typeof(DBetterContext))]
-    partial class DBetterContextModelSnapshot : ModelSnapshot
+    [Migration("20260405103025_TrainRunPassengerInformationShortId")]
+    partial class TrainRunPassengerInformationShortId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DBetter.Infrastructure/Migrations/20260405103025_TrainRunPassengerInformationShortId.cs
+++ b/DBetter.Infrastructure/Migrations/20260405103025_TrainRunPassengerInformationShortId.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DBetter.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class TrainRunPassengerInformationShortId : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "TrainRunPassengerInformation",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false),
+                    TrainRunId = table.Column<Guid>(type: "uuid", nullable: false),
+                    PassengerInformationId = table.Column<Guid>(type: "uuid", nullable: false),
+                    FromStopIndex = table.Column<int>(type: "integer", nullable: false),
+                    ToStopIndex = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TrainRunPassengerInformation", x => new { x.TrainRunId, x.Id });
+                    table.ForeignKey(
+                        name: "FK_TrainRunPassengerInformation_TrainRuns_TrainRunId",
+                        column: x => x.TrainRunId,
+                        principalTable: "TrainRuns",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TrainRunPassengerInformation_Id_TrainRunId",
+                table: "TrainRunPassengerInformation",
+                columns: new[] { "Id", "TrainRunId" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "TrainRunPassengerInformation");
+        }
+    }
+}

--- a/DBetter.Infrastructure/TrainRuns/TrainRunMapping.cs
+++ b/DBetter.Infrastructure/TrainRuns/TrainRunMapping.cs
@@ -19,17 +19,20 @@ public class TrainRunMapping : IEntityTypeConfiguration<TrainRunPersistenceDto>
         
         builder.HasIndex(x => new {x.TrainCirculationId, x.OperatingDay})
             .IsUnique();
-
+        
         builder.OwnsMany(x => x.PassengerInformation, pib =>
         {
             pib.ToTable("TrainRunPassengerInformation");
-
+        
             pib.WithOwner().HasForeignKey("TrainRunId");
-
+        
             pib.HasKey("TrainRunId", nameof(TrainRunPassengerInformationPersistenceDto.Id));
-
+        
             pib.HasIndex(nameof(TrainRunPassengerInformation.Id), "TrainRunId")
                 .IsUnique();
+        
+            pib.Property(x => x.Id)
+                .ValueGeneratedNever();
         });
     }
 }

--- a/DBetter.Infrastructure/TrainRuns/TrainRunMapping.cs
+++ b/DBetter.Infrastructure/TrainRuns/TrainRunMapping.cs
@@ -23,11 +23,11 @@ public class TrainRunMapping : IEntityTypeConfiguration<TrainRunPersistenceDto>
         builder.OwnsMany(x => x.PassengerInformation, pib =>
         {
             pib.ToTable("TrainRunPassengerInformation");
-            
+
             pib.WithOwner().HasForeignKey("TrainRunId");
-            
-            pib.HasKey(x => x.Id);
-            
+
+            pib.HasKey("TrainRunId", nameof(TrainRunPassengerInformationPersistenceDto.Id));
+
             pib.HasIndex(nameof(TrainRunPassengerInformation.Id), "TrainRunId")
                 .IsUnique();
         });

--- a/DBetter.Infrastructure/TrainRuns/TrainRunPassengerInformationPersistenceDto.cs
+++ b/DBetter.Infrastructure/TrainRuns/TrainRunPassengerInformationPersistenceDto.cs
@@ -7,7 +7,7 @@ namespace DBetter.Infrastructure.TrainRuns;
 
 public class TrainRunPassengerInformationPersistenceDto: IPersistenceDto<TrainRunPassengerInformation>
 {
-    public required Guid Id { get; init; }
+    public required ushort Id { get; init; }
     
     public required Guid PassengerInformationId { get; set; }
     


### PR DESCRIPTION
* Fixes crash when passenger information of train run will be added after initialization by correcting primary database key
* Migrate `TrainRunPassengerInformationId` from guid to ushort

:warning: The migrations of this pull request will result in a data loss of all passenger information assigned to the train runs due to the id change!