### PR TITLE
Implement route query for train composition service

### DIFF
--- a/DBetter.Api/TrainRunModule.cs
+++ b/DBetter.Api/TrainRunModule.cs
@@ -1,10 +1,16 @@
+using System.Numerics;
 using CleanDomainValidation.Application;
 using CleanMediator;
+using CleanMediator.Commands;
+using CleanMediator.Queries;
 using DBetter.Application.TrainCompositions.Get;
 using DBetter.Application.TrainRuns.Queries.Get;
+using DBetter.Application.TrainRuns.Queries.GetRoute;
 using DBetter.Contracts.TrainCompositions.Get;
 using DBetter.Contracts.TrainRuns.Queries.Get;
 using DBetter.Contracts.TrainRuns.Queries.Get.Results;
+using DBetter.Contracts.TrainRuns.Queries.GetRoute;
+using Microsoft.OpenApi;
 
 namespace DBetter.Api;
 
@@ -14,8 +20,24 @@ public static class TrainRunModule
     {
         app.MapGet("train-runs/{id}", async (
                 IMediator mediator,
+                HttpContext httpContext,
                 string id) =>
             {
+                var acceptHeader = httpContext.Request.Headers.Accept.ToString();
+                if (acceptHeader is "application/dbetter.route-only+json")
+                {
+                    var routeOnlyQuery = Builder<GetRouteQuery>
+                        .WithName("TrainRun.GetRoute")
+                        .BindParameters(new GetRouteParameters())
+                        .MapParameter(p => p.Id, id)
+                        .BuildUsing<GetRouteQueryBuilder>();
+
+                    return await mediator.HandleQueryAsync(routeOnlyQuery, (RouteResponse result) =>
+                    {
+                        return Results.Ok(result);
+                    });
+                }
+
                 var query = Builder<GetTrainRunQuery>
                     .WithName("TrainRun.Get")
                     .BindParameters(new GetTrainRunParameters())
@@ -27,9 +49,9 @@ public static class TrainRunModule
                     return Results.Ok(result);
                 });
             })
-        .WithName("GetTrainRun")
-        .Produces<TrainRunResponse>()
-        .WithOpenApi();
+            .WithName("GetTrainRun")
+            .Produces<TrainRunResponse>(200, "application/json")
+            .Produces<RouteResponse>(200, "application/dbetter.route-only+json");
         
         app.MapGet("train-runs/{id}/trainComposition", async (
                 IMediator mediator,

--- a/DBetter.Application/TrainRuns/Queries/GetRoute/GetRouteQuery.cs
+++ b/DBetter.Application/TrainRuns/Queries/GetRoute/GetRouteQuery.cs
@@ -1,0 +1,21 @@
+using CleanDomainValidation.Application;
+using CleanDomainValidation.Application.Extensions;
+using CleanMediator.Queries;
+using DBetter.Contracts.TrainRuns.Queries.GetRoute;
+using DBetter.Domain.TrainRuns.ValueObjects;
+
+namespace DBetter.Application.TrainRuns.Queries.GetRoute;
+
+public class GetRouteQueryBuilder : IRequestBuilder<GetRouteParameters, GetRouteQuery>
+{
+    public ValidatedRequiredProperty<GetRouteQuery> Configure(RequiredPropertyBuilder<GetRouteParameters, GetRouteQuery> builder)
+    {
+        var id = builder.ClassProperty(r => r.TrainRunId)
+            .Required()
+            .Map(p => p.Id, TrainRunId.Create);
+        
+        return builder.Build(() => new GetRouteQuery(id));
+    }
+}
+
+public record GetRouteQuery(TrainRunId TrainRunId): IQuery<RouteResponse>;

--- a/DBetter.Application/TrainRuns/Queries/GetRoute/GetRouteQueryHandler.cs
+++ b/DBetter.Application/TrainRuns/Queries/GetRoute/GetRouteQueryHandler.cs
@@ -1,0 +1,58 @@
+using CleanDomainValidation.Domain;
+using CleanMediator.Queries;
+using DBetter.Application.Requests.GetSuggestions;
+using DBetter.Contracts.TrainRuns.Queries.GetRoute;
+using DBetter.Domain.Errors;
+using DBetter.Domain.Routes;
+using DBetter.Domain.Stations;
+using DBetter.Domain.TrainCirculations;
+using DBetter.Domain.TrainRuns;
+
+namespace DBetter.Application.TrainRuns.Queries.GetRoute;
+
+public class GetRouteQueryHandler(
+    ITrainRunRepository trainRunRepository,
+    ITrainCirculationRepository trainCirculationRepository,
+    IStationRepository stationRepository,
+    IRouteRepository routeRepository): QueryHandlerBase<GetRouteQuery, RouteResponse>
+{
+    public override async Task<CanFail<RouteResponse>> Handle(GetRouteQuery query, CancellationToken cancellationToken)
+    {
+        var trainRun = await trainRunRepository.GetAsync(query.TrainRunId);
+        if (trainRun is null) return DomainErrors.TrainRun.NotFound(query.TrainRunId);
+        var route = await routeRepository.GetAsync(query.TrainRunId);
+        if (route is null) return DomainErrors.Route.NotFound;
+
+        var trainCirculation = await trainCirculationRepository.GetAsync(trainRun.CirculationId);
+        if (trainCirculation is null) throw new InvalidOperationException("Train Circulation does not exist");
+        
+        var stations = await stationRepository.GetManyAsync(route.Stops.Select(s => s.StationId));
+
+        return new RouteResponse
+        {
+            ServiceNumber = trainCirculation.ServiceInformation.ServiceNumber?.Value,
+            Stops = BuildRoute(route, stations)
+        };
+    }
+
+    private List<RouteStopResponse> BuildRoute(Route route, List<Station> stations)
+    {
+        var stops = new List<RouteStopResponse>();
+        var stopIndex = 0;
+        foreach (var stop in route.Stops)
+        {
+            var evaNumber = stations.First(s => s.Id == stop.StationId).EvaNumber;
+            stops.Add(new RouteStopResponse
+            {
+                Id = stop.StationId.Value.ToString(),
+                EvaNumber = evaNumber.Value,
+                DepartureTime = stop.DepartureTime?.ToResponse(),
+                ArrivalTime = stop.ArrivalTime?.ToResponse(),
+                Platform = stop.Platform?.ToResponse(),
+                RouteIndex = stopIndex
+            });
+            stopIndex++;
+        }
+        return stops;
+    }
+}

--- a/DBetter.Contracts/TrainRuns/Queries/GetRoute/GetRouteParameters.cs
+++ b/DBetter.Contracts/TrainRuns/Queries/GetRoute/GetRouteParameters.cs
@@ -1,0 +1,13 @@
+using System.Text.Json.Serialization;
+using CleanDomainValidation.Application;
+
+namespace DBetter.Contracts.TrainRuns.Queries.GetRoute;
+
+public class GetRouteParameters: IParameters
+{
+    /// <summary>
+    /// Id of the train run
+    /// </summary>
+    [JsonIgnore]
+    public string? Id { get; set; }
+}

--- a/DBetter.Contracts/TrainRuns/Queries/GetRoute/RouteResponse.cs
+++ b/DBetter.Contracts/TrainRuns/Queries/GetRoute/RouteResponse.cs
@@ -1,0 +1,8 @@
+namespace DBetter.Contracts.TrainRuns.Queries.GetRoute;
+
+public class RouteResponse
+{
+    public required int? ServiceNumber { get; init; }
+    
+    public required List<RouteStopResponse> Stops { get; init; }
+}

--- a/DBetter.Contracts/TrainRuns/Queries/GetRoute/RouteStopResponse.cs
+++ b/DBetter.Contracts/TrainRuns/Queries/GetRoute/RouteStopResponse.cs
@@ -1,0 +1,36 @@
+using DBetter.Contracts.Shared.DTOs;
+
+namespace DBetter.Contracts.TrainRuns.Queries.GetRoute;
+
+public class RouteStopResponse
+{
+    /// <summary>
+    /// Internal id of the station
+    /// </summary>
+    public required string Id { get; init; }
+    
+    /// <summary>
+    /// Eva number of the station
+    /// </summary>
+    public required string EvaNumber { get; init; }
+
+    /// <summary>
+    /// Departure time
+    /// </summary>
+    public required TravelTimeDto? DepartureTime { get; init; }
+    
+    /// <summary>
+    /// Arrival time
+    /// </summary>
+    public required TravelTimeDto? ArrivalTime { get; init; }
+    
+    /// <summary>
+    /// Platform
+    /// </summary>
+    public required PlatformDto? Platform { get; init; }
+    
+    /// <summary>
+    /// Stop index of the full train run
+    /// </summary>
+    public required int RouteIndex { get; init; }
+}

--- a/DBetter.Domain/Errors/DomainErrors.Route.cs
+++ b/DBetter.Domain/Errors/DomainErrors.Route.cs
@@ -6,6 +6,9 @@ public static partial class DomainErrors
 {
     public static class Route
     {
+        public static Error NotFound =>
+            Error.NotFound("Route.NotFound", "The route for this train has not been scraped.");
+        
         public static class Id
         {
             public static Error Invalid(string value) => Error.Validation("Route.Id.Invalid", $"{value} is no valid guid.");

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,31 +1,21 @@
 services:
   postgres:
     image: postgres:latest
-    container_name: postgres_db
+    container_name: dbetter-postgres
     restart: unless-stopped
     environment:
-      POSTGRES_USER: user
+      POSTGRES_USER: postgres
       POSTGRES_PASSWORD: password
     ports:
       - "5432:5432"
     volumes:
-      - postgres_data:/var/lib/postgresql/data
-    networks:
-      - postgres_network
-  postgres-frontend:
-    image: dpage/pgadmin4
-    container_name: postgres_frontend
-    restart: unless-stopped
-    environment:
-      PGADMIN_DEFAULT_EMAIL: test@test.de
-      PGADMIN_DEFAULT_PASSWORD: password
+      - postgres_data:/var/lib/postgresql
+  rabbitmq:
+    image: rabbitmq:4-management
+    container_name: dbetter-rabbitmq
     ports:
-      - "5050:80"
-    networks:
-      - postgres_network
+      - "15672:15672"
+      - "5672:5672"
 
 volumes:
   postgres_data:
-
-networks:
-  postgres_network:


### PR DESCRIPTION
Extend GET `train-run/{id}` endpoint to return only route information including the eva number of the stop. when using accept header `application/dbetter.route-only+json`